### PR TITLE
Chunked uploading for files over 100M

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 packer-post-processor-vagrant-s3
+*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+packer-post-processor-vagrant-s3

--- a/post-processor.go
+++ b/post-processor.go
@@ -171,17 +171,18 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 
 		ui.Message("Uploading...")
 
-		const chunkSize = 5*1024*1024
+		const chunkSize = 10*1024*1024
 
 		totalParts := uint64(math.Ceil(float64(size) / float64(chunkSize)))
+		totalUploadSize := int64(0)
 
 		parts := []s3.Part{}
 
 		errorCount := 0;
 
-		for partNum := uint64(1); partNum < totalParts; partNum++ {
+		for partNum := uint64(1); partNum <= totalParts; partNum++ {
 
-			partSize := int64(math.Min(chunkSize, float64(size-int64(partNum*chunkSize))))
+			partSize := int(math.Min(chunkSize, float64(size-int64(partNum*chunkSize))))
 			partBuffer := make([]byte, partSize)
 
 			ui.Message(fmt.Sprintf("Upload: Uploading part %d, %d (of max %d) bytes", int(partNum), int(partSize), int(chunkSize)))
@@ -192,8 +193,6 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 			bufferReader := bytes.NewReader(partBuffer)
 			part, err := multi.PutPart(int(partNum), bufferReader)
 
-			ui.Message(fmt.Sprintf("Upload: done %d of %d, uploaded %d bytes...", int(partNum), int(totalParts), int(part.Size)*int(partNum)))
-
 			parts = append(parts, part)
 
 			if err != nil {
@@ -202,11 +201,15 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 					errorCount++
 					ui.Message(fmt.Sprintf("Error encountered! %s. Retry %d", err, errorCount))
 					time.Sleep(2000 * time.Millisecond)
-					partNum++
+					partNum--
 				} else {
+					ui.Message(fmt.Sprintf("Too many errors encountered! Aborting.", err, errorCount))
 					return nil, false, err
 				}
 			}
+
+			totalUploadSize += part.Size
+			ui.Message(fmt.Sprintf("Upload: done %d of %d, uploaded %d bytes...", int(partNum), int(totalParts), int(totalUploadSize)))
 
 		}
 

--- a/post-processor.go
+++ b/post-processor.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"math"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -10,6 +11,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/mitchellh/goamz/aws"
 	"github.com/mitchellh/goamz/s3"
@@ -161,14 +163,44 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 	}
 	if size > 100*1024*1024 {
 		ui.Message("File size > 100MB. Initiating multipart upload")
-		multi, err := p.s3.Multi(boxPath, "application/octet-stream", "public-read")
+
+		multi, err := p.s3.InitMulti(boxPath, "application/octet-stream", "public-read")
 		if err != nil {
 			return nil, false, err
 		}
-		parts, err := multi.PutAll(file, 5*1024*1024)
-		if err != nil {
-			return nil, false, err
+
+		ui.Message("Uploading...")
+		chunkSize := uint64(5*1024*1024)
+		totalParts := uint64(math.Ceil(float64(size) / float64(chunkSize)))
+
+		parts := []s3.Part{}
+
+		errorCount := 0;
+
+		for partNum := uint64(1); partNum < totalParts; partNum++ {
+
+			partSize := int(math.Min(float64(chunkSize), float64(size-int64(partNum*chunkSize))))
+			partBuffer := make([]byte, partSize)
+
+			file.Read(partBuffer)
+			part, err := multi.PutPart(int(partNum), file)
+
+			ui.Message(fmt.Sprintf("Upload: %d of %d, uploaded %d bytes...", int(partNum), int(totalParts), int(part.Size)*int(partNum)))
+
+			parts = append(parts, part)
+
+			if err != nil {
+
+				if errorCount < 10 {
+					time.Sleep(100 * time.Millisecond)
+					partNum--
+				} else {
+					return nil, false, err
+				}
+			}
+
 		}
+
 		if err := multi.Complete(parts); err != nil {
 			return nil, false, err
 		}

--- a/post-processor.go
+++ b/post-processor.go
@@ -182,10 +182,11 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 
 		for partNum := uint64(1); partNum <= totalParts; partNum++ {
 
-			partSize := int(math.Min(chunkSize, float64(size-int64(partNum*chunkSize))))
+			filePos, err := file.Seek(0,1)
+			partSize := int(math.Min(chunkSize, float64(size - filePos)))
 			partBuffer := make([]byte, partSize)
 
-			ui.Message(fmt.Sprintf("Upload: Uploading part %d, %d (of max %d) bytes", int(partNum), int(partSize), int(chunkSize)))
+			ui.Message(fmt.Sprintf("Upload: Uploading part %d of %d, %d (of max %d) bytes", int(partNum), int(totalParts), int(partSize), int(chunkSize)))
 
 		  readBytes, err := file.Read(partBuffer)
 			ui.Message(fmt.Sprintf("Upload: Read %d bytes from box file on disk", readBytes))
@@ -209,7 +210,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 			}
 
 			totalUploadSize += part.Size
-			ui.Message(fmt.Sprintf("Upload: done %d of %d, uploaded %d bytes...", int(partNum), int(totalParts), int(totalUploadSize)))
+			ui.Message(fmt.Sprintf("Upload: Finished part %d of %d, upload total is %d bytes. This part was %d bytes.", int(partNum), int(totalParts), int(totalUploadSize), int(part.Size)))
 
 		}
 

--- a/post-processor.go
+++ b/post-processor.go
@@ -170,7 +170,9 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 		}
 
 		ui.Message("Uploading...")
-		chunkSize := uint64(5*1024*1024)
+
+		const chunkSize = 5*1024*1024
+
 		totalParts := uint64(math.Ceil(float64(size) / float64(chunkSize)))
 
 		parts := []s3.Part{}
@@ -179,21 +181,28 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 
 		for partNum := uint64(1); partNum < totalParts; partNum++ {
 
-			partSize := int(math.Min(float64(chunkSize), float64(size-int64(partNum*chunkSize))))
+			partSize := int64(math.Min(chunkSize, float64(size-int64(partNum*chunkSize))))
 			partBuffer := make([]byte, partSize)
 
-			file.Read(partBuffer)
-			part, err := multi.PutPart(int(partNum), file)
+			ui.Message(fmt.Sprintf("Upload: Uploading part %d, %d (of max %d) bytes", int(partNum), int(partSize), int(chunkSize)))
 
-			ui.Message(fmt.Sprintf("Upload: %d of %d, uploaded %d bytes...", int(partNum), int(totalParts), int(part.Size)*int(partNum)))
+		  readBytes, err := file.Read(partBuffer)
+			ui.Message(fmt.Sprintf("Upload: Read %d bytes from box file on disk", readBytes))
+
+			bufferReader := bytes.NewReader(partBuffer)
+			part, err := multi.PutPart(int(partNum), bufferReader)
+
+			ui.Message(fmt.Sprintf("Upload: done %d of %d, uploaded %d bytes...", int(partNum), int(totalParts), int(part.Size)*int(partNum)))
 
 			parts = append(parts, part)
 
 			if err != nil {
 
 				if errorCount < 10 {
-					time.Sleep(100 * time.Millisecond)
-					partNum--
+					errorCount++
+					ui.Message(fmt.Sprintf("Error encountered! %s. Retry %d", err, errorCount))
+					time.Sleep(2000 * time.Millisecond)
+					partNum++
 				} else {
 					return nil, false, err
 				}

--- a/post-processor.go
+++ b/post-processor.go
@@ -204,7 +204,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 					ui.Message(fmt.Sprintf("Error encountered! %s. Retry %d.", err, errorCount))
 					time.Sleep(5 * time.Second)
 					//reset seek position to the beginning of this block
-					file.Seek(filePos - partSize, 0)
+					file.Seek(filePos, 0)
 					partNum--
 				} else {
 					ui.Message(fmt.Sprintf("Too many errors encountered! Aborting.", err, errorCount))


### PR DESCRIPTION
I've rewritten the chunked uploading handling, to implement handling by 10MB chunk, status output and retries should an individual chunk fail to upload. I couldn't get a chunked upload to complete on my slowish (1Mbit up) ADSL line, but with the new changes I can upload generated boxes no problems.