### PR TITLE
Chunking of multipart uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 packer-post-processor-vagrant-s3
+*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+packer-post-processor-vagrant-s3

--- a/post-processor.go
+++ b/post-processor.go
@@ -207,7 +207,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 					ui.Message(fmt.Sprintf("Error encountered! %s. Retry %d.", err, errorCount))
 					time.Sleep(5 * time.Second)
 					//reset seek position to the beginning of this block
-					file.Seek(filePos - partSize, 0)
+					file.Seek(filePos, 0)
 					partNum--
 				} else {
 					ui.Message(fmt.Sprintf("Too many errors encountered! Aborting.", err, errorCount))

--- a/post-processor.go
+++ b/post-processor.go
@@ -185,10 +185,11 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 
 		for partNum := uint64(1); partNum <= totalParts; partNum++ {
 
-			partSize := int(math.Min(chunkSize, float64(size-int64(partNum*chunkSize))))
+			filePos, err := file.Seek(0,1)
+			partSize := int(math.Min(chunkSize, float64(size - filePos)))
 			partBuffer := make([]byte, partSize)
 
-			ui.Message(fmt.Sprintf("Upload: Uploading part %d, %d (of max %d) bytes", int(partNum), int(partSize), int(chunkSize)))
+			ui.Message(fmt.Sprintf("Upload: Uploading part %d of %d, %d (of max %d) bytes", int(partNum), int(totalParts), int(partSize), int(chunkSize)))
 
 		  readBytes, err := file.Read(partBuffer)
 			ui.Message(fmt.Sprintf("Upload: Read %d bytes from box file on disk", readBytes))
@@ -212,7 +213,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 			}
 
 			totalUploadSize += part.Size
-			ui.Message(fmt.Sprintf("Upload: done %d of %d, uploaded %d bytes...", int(partNum), int(totalParts), int(totalUploadSize)))
+			ui.Message(fmt.Sprintf("Upload: Finished part %d of %d, upload total is %d bytes. This part was %d bytes.", int(partNum), int(totalParts), int(totalUploadSize), int(part.Size)))
 
 		}
 

--- a/post-processor.go
+++ b/post-processor.go
@@ -181,17 +181,18 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 
 		parts := []s3.Part{}
 
-		errorCount := 0;
+		errorCount := 0
 
 		for partNum := uint64(1); partNum <= totalParts; partNum++ {
 
 			filePos, err := file.Seek(0,1)
-			partSize := int(math.Min(chunkSize, float64(size - filePos)))
+			
+			partSize := int64(math.Min(chunkSize, float64(size - filePos)))
 			partBuffer := make([]byte, partSize)
 
 			ui.Message(fmt.Sprintf("Upload: Uploading part %d of %d, %d (of max %d) bytes", int(partNum), int(totalParts), int(partSize), int(chunkSize)))
 
-		  readBytes, err := file.Read(partBuffer)
+		  	readBytes, err := file.Read(partBuffer)
 			ui.Message(fmt.Sprintf("Upload: Read %d bytes from box file on disk", readBytes))
 
 			bufferReader := bytes.NewReader(partBuffer)
@@ -203,18 +204,20 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 
 				if errorCount < 10 {
 					errorCount++
-					ui.Message(fmt.Sprintf("Error encountered! %s. Retry %d", err, errorCount))
-					time.Sleep(2000 * time.Millisecond)
+					ui.Message(fmt.Sprintf("Error encountered! %s. Retry %d.", err, errorCount))
+					time.Sleep(5 * time.Second)
+					//reset seek position to the beginning of this block
+					file.Seek(filePos - partSize, 0)
 					partNum--
 				} else {
 					ui.Message(fmt.Sprintf("Too many errors encountered! Aborting.", err, errorCount))
 					return nil, false, err
 				}
+			} else {
+
+				totalUploadSize += part.Size
+				ui.Message(fmt.Sprintf("Upload: Finished part %d of %d, upload total is %d bytes. This part was %d bytes.", int(partNum), int(totalParts), int(totalUploadSize), int(part.Size)))
 			}
-
-			totalUploadSize += part.Size
-			ui.Message(fmt.Sprintf("Upload: Finished part %d of %d, upload total is %d bytes. This part was %d bytes.", int(partNum), int(totalParts), int(totalUploadSize), int(part.Size)))
-
 		}
 
 		if err := multi.Complete(parts); err != nil {

--- a/post-processor.go
+++ b/post-processor.go
@@ -179,7 +179,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 		totalParts := uint64(math.Ceil(float64(size) / float64(chunkSize)))
 		totalUploadSize := int64(0)
 
-		parts := []s3.Part{}
+		parts := make([]s3.Part, totalParts)
 
 		errorCount := 0
 

--- a/post-processor.go
+++ b/post-processor.go
@@ -220,7 +220,7 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 			}
 		}
 
-		ui.Message('Parts uploaded, completing upload...')
+		ui.Message("Parts uploaded, completing upload...")
 		if err := multi.Complete(parts); err != nil {
 			return nil, false, err
 		}


### PR DESCRIPTION
Hi, as discussed in previous pull request, these changes allow uploads to be done in chunks which allows for better feedback on upload process, but also allows individual 5MB chunks to be retried if they fail. I've tested this code over a few different large boxes (500-800MB) and it's working well for me.

I've incorporated feedback from the previous pull request where needed as well.