### PR TITLE
Fix AWS credentials lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Vagrant.configure(2) do |config|
 end
 ```
 
-When pointing the `Vagrantfile` at a manifest instead of directly at a box you retain traditional features such as 
+When pointing the `Vagrantfile` at a manifest instead of directly at a box you retain traditional features such as
 versioning and multiple providers.
 
 Configuration
@@ -141,13 +141,13 @@ If not set, will use `public-read`.
 
 Your AWS access key.
 
-If not set, will use `AWS_ACCESS_KEY_ID` environment variable.
+If not set, will use the standard aws sdk credential chain - http://docs.aws.amazon.com/sdk-for-go/latest/v1/developerguide/configuring-sdk.title.html
 
 ### secret_key (optional)
 
 Your AWS secret key.
 
-If not set, will use `AWS_SECRET_ACCESS_KEY` environment variable.
+If not set, will use the standard aws sdk credential chain - http://docs.aws.amazon.com/sdk-for-go/latest/v1/developerguide/configuring-sdk.title.html
 
 ### signed_expiry (optional)
 

--- a/post-processor.go
+++ b/post-processor.go
@@ -82,13 +82,20 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 		}
 	}
 
-	// create a session and an S3 service
-	accessKey := p.config.AccessKey
-	secretKey := p.config.SecretKey
-
+	var cred *credentials.Credentials = nil // nil credentials use the default aws sdk credential chain
+	// Setting either config variable indicates an attempt to use configred credentials
+	if p.config.AccessKey != "" || p.config.SecretKey != "" {
+		cred = credentials.NewCredentials(&credentials.StaticProvider{
+			Value: credentials.Value{
+				AccessKeyID:     p.config.AccessKey,
+				SecretAccessKey: p.config.SecretKey,
+				ProviderName:    "plugin-conf",
+			},
+		})
+	}
 	p.session = session.New(&aws.Config{
 		Region:      aws.String(p.config.Region),
-		Credentials: credentials.NewStaticCredentials(accessKey, secretKey, ""),
+		Credentials: cred,
 	})
 
 	p.s3 = s3.New(p.session)

--- a/post-processor.go
+++ b/post-processor.go
@@ -83,7 +83,7 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 	}
 
 	var cred *credentials.Credentials = nil // nil credentials use the default aws sdk credential chain
-	// Setting either config variable indicates an attempt to use configred credentials
+	// Setting either credential config variable indicates an attempt to use configured credentials
 	if p.config.AccessKey != "" || p.config.SecretKey != "" {
 		cred = credentials.NewCredentials(&credentials.StaticProvider{
 			Value: credentials.Value{


### PR DESCRIPTION
Commit 64759037ef344586abc82cbe704cb767059ec62d broke the abiilty to read AWS credentials from environment variables.

This change uses the standard credential lookup when not manually specifying aws credentials in the plugin config.