### PR TITLE
Provide pre-built binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-packer-post-processor-vagrant-s3
+packer-post-processor-vagrant-s3*
 *.swp
 .idea

--- a/README.md
+++ b/README.md
@@ -5,12 +5,22 @@ Uploads built Vagrant boxes to S3 and manages a manifest file for versioned boxe
 
 Installation
 ------------
-Install the binary (you'll need ```git``` and ```go```):
+
+### Pre-built binaries
+
+The easiest way to install this post-processor is to download a pre-built binary. The builds are hosted 
+[here](http://packer-builder-upcloud-build-host.negge.fi/). Follow the link, download the correct binary for your 
+platform, then rename the file to `packer-post-processor-vagrant-s3` and place it in `~/.packer.d/plugins` so 
+that Packer can find it (create the directory if it doesn't exist).
+
+### Building from source
+
+You'll need git and go installed for this. First, download the code by running the following command:
 
 ```
 $ go get github.com/lmars/packer-post-processor-vagrant-s3
 ```
-Copy the plugin into packer.d directory:
+Then, copy the plugin into `~/.packer.d/plugins` directory:
 
 ```
 $ mkdir $HOME/.packer.d/plugins

--- a/builds.html
+++ b/builds.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>packer-post-processor-vagrant-s3 builds</title>
+</head>
+<body>
+
+<h1>packer-post-processor-vagrant-s3 builds</h1>
+<p>
+  This page contains pre-built binaries for the <a href="https://github.com/lmars/packer-post-processor-vagrant-s3">Packer
+  Vagrant S3 post-processor</a>. Refresh this page by pressing F5 if you've visited it previously and you suspect the contents
+  have
+  changed, but you're not seeing any changes.
+</p>
+<p>
+  The binaries are built using <a href="https://github.com/mitchellh/gox">gox</a>.
+</p>
+
+<h2>Binaries (revision c1d15c92b359cd38438d7a7c599296fa80ab8226)</h2>
+
+<ul>
+  <li><a
+      href="http://packer-post-processor-vagrant-s3-build-host.negge.fi/packer-post-processor-vagrant-s3_darwin_386">packer-post-processor-vagrant-s3_darwin_386</a>
+  </li>
+  <li><a
+      href="http://packer-post-processor-vagrant-s3-build-host.negge.fi/packer-post-processor-vagrant-s3_darwin_amd64">packer-post-processor-vagrant-s3_darwin_amd64</a>
+  </li>
+  <li><a
+      href="http://packer-post-processor-vagrant-s3-build-host.negge.fi/packer-post-processor-vagrant-s3_freebsd_386">packer-post-processor-vagrant-s3_freebsd_386</a>
+  </li>
+  <li><a
+      href="http://packer-post-processor-vagrant-s3-build-host.negge.fi/packer-post-processor-vagrant-s3_freebsd_amd64">packer-post-processor-vagrant-s3_freebsd_amd64</a>
+  </li>
+  <li><a
+      href="http://packer-post-processor-vagrant-s3-build-host.negge.fi/packer-post-processor-vagrant-s3_freebsd_arm">packer-post-processor-vagrant-s3_freebsd_arm</a>
+  </li>
+  <li><a
+      href="http://packer-post-processor-vagrant-s3-build-host.negge.fi/packer-post-processor-vagrant-s3_linux_386">packer-post-processor-vagrant-s3_linux_386</a>
+  </li>
+  <li><a
+      href="http://packer-post-processor-vagrant-s3-build-host.negge.fi/packer-post-processor-vagrant-s3_linux_amd64">packer-post-processor-vagrant-s3_linux_amd64</a>
+  </li>
+  <li><a
+      href="http://packer-post-processor-vagrant-s3-build-host.negge.fi/packer-post-processor-vagrant-s3_linux_arm">packer-post-processor-vagrant-s3_linux_arm</a>
+  </li>
+  <li><a
+      href="http://packer-post-processor-vagrant-s3-build-host.negge.fi/packer-post-processor-vagrant-s3_netbsd_386">packer-post-processor-vagrant-s3_netbsd_386</a>
+  </li>
+  <li><a
+      href="http://packer-post-processor-vagrant-s3-build-host.negge.fi/packer-post-processor-vagrant-s3_netbsd_amd64">packer-post-processor-vagrant-s3_netbsd_amd64</a>
+  </li>
+  <li><a
+      href="http://packer-post-processor-vagrant-s3-build-host.negge.fi/packer-post-processor-vagrant-s3_netbsd_arm">packer-post-processor-vagrant-s3_netbsd_arm</a>
+  </li>
+  <li><a
+      href="http://packer-post-processor-vagrant-s3-build-host.negge.fi/packer-post-processor-vagrant-s3_openbsd_386">packer-post-processor-vagrant-s3_openbsd_386</a>
+  </li>
+  <li><a
+      href="http://packer-post-processor-vagrant-s3-build-host.negge.fi/packer-post-processor-vagrant-s3_openbsd_amd64">packer-post-processor-vagrant-s3_openbsd_amd64</a>
+  </li>
+  <li><a
+      href="http://packer-post-processor-vagrant-s3-build-host.negge.fi/packer-post-processor-vagrant-s3_windows_386.exe">packer-post-processor-vagrant-s3_windows_386.exe</a>
+  </li>
+  <li><a
+      href="http://packer-post-processor-vagrant-s3-build-host.negge.fi/packer-post-processor-vagrant-s3_windows_amd64.exe">packer-post-processor-vagrant-s3_windows_amd64.exe</a>
+  </li>
+</ul>
+
+<h2>Checksums (SHA256)</h2>
+
+<p>
+  If you're paranoid, you can compare the SHA256 checksum of your downloaded binary against the list below. This HTML
+  file is also available on <a
+    href="https://raw.githubusercontent.com/lmars/packer-post-processor-vagrant-s3/master/builds.html">Github</a>
+  if you're <i>really</i> paranoid.
+</p>
+
+<pre>
+c4e0cf4233f0058cdee69165c3aaab68a130aac18473f2f5f82f47e405703cf5  packer-post-processor-vagrant-s3_darwin_386
+c3d0ca7cef2f0133577b71067ddc4811f0ed993ac632fd400edc7e3c2153117e  packer-post-processor-vagrant-s3_darwin_amd64
+4bd5165536875e71cf429c5a78e441340dc347da4536d48879548f897090ac85  packer-post-processor-vagrant-s3_freebsd_386
+503e875bdc4ac0cb524883902c6fea31c6f64b10bb5cf790f87dd62145daf912  packer-post-processor-vagrant-s3_freebsd_amd64
+5cad181d24df9abd10fbdb3c85f4387b8b755594f0ddd305d16f45104aac222c  packer-post-processor-vagrant-s3_freebsd_arm
+79ec46a8b7905144cf2e773b55d897b8170e67a76d102c6c2d27e09fa3d87cf4  packer-post-processor-vagrant-s3_linux_386
+d2a71ac12153fda93b43dcf97b1f4be70c3e08b14ba3d646b183a32d621ce8fe  packer-post-processor-vagrant-s3_linux_amd64
+dd898d6627beedbec7da5bdb620448238277f510a11588066fb9a2bce31c69cc  packer-post-processor-vagrant-s3_linux_arm
+bb0c6cc87ce36f080fe32cc5cf44b0a6f8efd52e74a28f815edb7c65505f37c1  packer-post-processor-vagrant-s3_netbsd_386
+fc035102a26c9a1a85fe4b5489aec51ef6af2033cbe627450f5c62e9ab6394dd  packer-post-processor-vagrant-s3_netbsd_amd64
+140163828af6613a2ac7dda5bafd42f44c1c644456e61939b324a74aafc8745a  packer-post-processor-vagrant-s3_netbsd_arm
+fd49c420c5b21447931a211532fc3f881526864b01922c21a9d8adb9c84f4368  packer-post-processor-vagrant-s3_openbsd_386
+d4ea61716e3351b53e7be34f03550f3f0dd8e049d81658d26217cceb4b98e3e1  packer-post-processor-vagrant-s3_openbsd_amd64
+a219eee48c71585a72cc8b23d0dd2de3708cb53785fb2cf186c75e77b1914224  packer-post-processor-vagrant-s3_windows_386.exe
+b98e806d89aa19de7c9dc9cbfa2b226b27ae7364801eeb495ac66dec82bd9790  packer-post-processor-vagrant-s3_windows_amd64.exe
+</pre>
+
+</body>
+</html>


### PR DESCRIPTION
@lmars do you think this is a good idea? Please see http://packer-post-processor-vagrant-s3-build-host.negge.fi/. It would definitely make the installation instructions easier. 

I've done the same for my UpCloud Packer builder (see http://packer-builder-upcloud-build-host.negge.fi/) so I know the builds actually work.

If you're okay with this I'll update the README too.