### PR TITLE
Add how long an upload took to S3

### DIFF
--- a/post-processor.go
+++ b/post-processor.go
@@ -169,10 +169,15 @@ func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (pac
 
 	// upload the box to S3
 	ui.Message(fmt.Sprintf("Uploading box to S3: %s", boxPath))
+
+	start := time.Now()
 	err = p.uploadBox(box, boxPath)
 
 	if err != nil {
 		return nil, false, err
+	} else {
+		elapsed := time.Since(start)
+		ui.Message(fmt.Sprintf("Box upload took: %s", elapsed))
 	}
 
 	// get the latest manifest so we can add to it
@@ -300,7 +305,7 @@ func generateS3Url(region, bucket, cloudFront, key string) string {
 
 	if region == "us-east-1" {
 		return fmt.Sprintf("https://s3.amazonaws.com/%s/%s", bucket, key)
-	} 
+	}
 
 	return fmt.Sprintf("https://s3-%s.amazonaws.com/%s/%s", region, bucket, key)
 }


### PR DESCRIPTION
Useful for build environments with automated pushes so over time a correlation can be made between image sizes versus upload times.

```
==> virtualbox-iso (vagrant-s3): Preparing to upload box for 'virtualbox' provider to S3 bucket 'vagrant'
    virtualbox-iso (vagrant-s3): Box to upload: builds/virtualbox.box (851139554 bytes)
    virtualbox-iso (vagrant-s3): Using 609 as new version
    virtualbox-iso (vagrant-s3): Generating checksum
    virtualbox-iso (vagrant-s3): Checksum is 77884bccf282edefe754525e308b91398c975331496848493571de974850f900
    virtualbox-iso (vagrant-s3): Uploading box to S3: vagrant/boxes/xxx/yyy/609/virtualbox.box
    virtualbox-iso (vagrant-s3): Box upload took: 9m58.794447617s
    virtualbox-iso (vagrant-s3): Fetching latest manifest
    virtualbox-iso (vagrant-s3): Adding virtualbox 609 box to manifest
    virtualbox-iso (vagrant-s3): Uploading the manifest: vagrant/json/xxx/yyy.json
Build 'virtualbox-iso' finished.
```

Thanks!