### PR TITLE
Add the ability to specify the S3 storage class for uploaded box files

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,3 +173,7 @@ This can not be used in combination with the signed_expiry setting.
 
 If not set, generate normal s3 urls.
 
+### storage_class (optional)
+
+If set, the S3 storage class for the uploaded box file will be set to this. Defaults to `STANDARD`, which is the 
+default for S3. Valid values are `STANDARD`, `STANDARD_IA` (infrequent access), or `REDUCED_REDUNDANCY`.

--- a/post-processor.go
+++ b/post-processor.go
@@ -36,6 +36,7 @@ type Config struct {
 	AccessKey           string        `mapstructure:"access_key_id"`
 	SecretKey           string        `mapstructure:"secret_key"`
 	SignedExpiry        time.Duration `mapstructure:"signed_expiry"`
+	StorageClass        string        `mapstructure:"storage_class"`
 	common.PackerConfig `mapstructure:",squash"`
 
 	ctx interpolate.Context
@@ -112,6 +113,11 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 
 	if p.config.ACL == "" {
 		p.config.ACL = "public-read"
+	}
+
+	// set default storage class
+	if p.config.StorageClass == "" {
+		p.config.StorageClass = "STANDARD"
 	}
 
 	if len(errs.Errors) > 0 {
@@ -244,10 +250,11 @@ func (p *PostProcessor) uploadBox(box, boxPath string) error {
 	})
 
 	_, err = uploader.Upload(&s3manager.UploadInput{
-		Body:   file,
-		Bucket: aws.String(p.config.Bucket),
-		Key:    aws.String(boxPath),
-		ACL:    aws.String(p.config.ACL),
+		Body:         file,
+		Bucket:       aws.String(p.config.Bucket),
+		Key:          aws.String(boxPath),
+		ACL:          aws.String(p.config.ACL),
+		StorageClass: aws.String(p.config.StorageClass),
 	})
 
 	return err


### PR DESCRIPTION
Closes #36 

Especially the `STANDARD_IA` ("infrequent access") storage class seems particularly fitting for this application.

@lmars can you review? Should be pretty straight-forward. The manifest file is always uploaded with `STANDARD` storage class since it's potentially more valuable than the box file itself.