### PR TITLE
Move to hashicorp

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/mitchellh/packer/packer/plugin"
+import "github.com/hashicorp/packer/packer/plugin"
 
 func main() {
 	server, err := plugin.Server()

--- a/post-processor.go
+++ b/post-processor.go
@@ -18,10 +18,10 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
-	"github.com/mitchellh/packer/common"
-	"github.com/mitchellh/packer/helper/config"
-	"github.com/mitchellh/packer/packer"
-	"github.com/mitchellh/packer/template/interpolate"
+	"github.com/hashicorp/packer/common"
+	"github.com/hashicorp/packer/helper/config"
+	"github.com/hashicorp/packer/packer"
+	"github.com/hashicorp/packer/template/interpolate"
 )
 
 type Config struct {


### PR DESCRIPTION
Hello,

There was a repository change:

From >>>> github.com/mitchellh/packer

For >>>>> github.com/hashicorp/packer/packer/plugin

And when trying to compile the error occurred:

```
Github.com/lmars/packer-post-processor-vagrant-s3
Go / src / github.com / lmars / packer-post-processor-vagrant-s3 / main.go: 10: can not use PostProcessor literal (type * PostProcessor) as type "github.com/hashicorp/packer/packer".PostProcessor In argument to server.RegisterPostProcessor:
* PostProcessor does not implement "github.com/hashicorp/packer/packer".PostProcessor (wrong type for PostProcess method)
Have PostProcess ("github.com/mitchellh/packer/packer" .Ui, "github.com/mitchellh/packer/packer".Artifact) (" github.com/mitchellh/packer/packer".Artifact, bool, error)
Want PostProcess ("github.com/hashicorp/packer/packer" .Ui, "github.com/hashicorp/packer/packer".Artifact) (" github.com/hashicorp/packer/packer".Artifact, bool, error)
Go / src / github.com / lmars / packer-post-processor-vagrant-s3 / post-processor.go: 57: can not use & p.config.ctx (type * "github.com/mitchellh/packer/template/interpolate ".Context) as type *" github.com/hashicorp/packer/template/interpolate ".Context in field value
Go / src / github.com / lmars / packer-post-processor-vagrant-s3 / post-processor.go: 60: can not use "github.com/mitchellh/packer/template/interpolate".RenderFilter literal (type * Github.com/mitchellh/packer/template/interpolate".RenderFilter) as type * "github.com/hashicorp/packer/template/interpolate" .RenderFilter in field value
```


Thank you